### PR TITLE
Fixes #103 : Create an options page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,9 @@
   "description": "Search FTP servers over the web for music, videos, eBooks and other content.",
   "version": "1.0",
   "web_accessible_resources": ["scripts/googleFearch.js"],
-
+  "options_ui": {
+    "page": "options/options.html"
+  },
   "permissions": ["*://www.google.com/*",
       "*://www.google.ad/*",
       "*://www.google.ae/*",

--- a/options/js/options.js
+++ b/options/js/options.js
@@ -1,0 +1,29 @@
+
+var radios = document.getElementsByName('theme');
+
+if(!localStorage.getItem('theme'))
+    localStorage.setItem('theme', 'light');
+
+if(localStorage.getItem('theme') == 'light')
+{
+    console.log("light");
+    radios[0].checked = true;
+}
+else
+{
+    console.log("dark");
+    radios[1].checked = true;
+}
+
+function handleThemeChange(event) {
+    if(event.target.value == 'light')
+        localStorage.setItem('theme', 'light');
+    else
+        localStorage.setItem('theme', 'dark');
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+    var radios = document.getElementsByName('theme');
+    radios[0].addEventListener('click', handleThemeChange);
+    radios[1].addEventListener('click', handleThemeChange);
+});

--- a/options/options.html
+++ b/options/options.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+  	<title>Fearch - Options</title>
+    <meta charset="utf-8">
+  </head>
+
+<body>
+  <form>
+		<label>
+			<b>Select theme</b>
+			<br />
+			<input type="radio" name="theme" value="light"> Light<br>
+  			<input type="radio" name="theme" value="dark"> Dark<br>		
+  		</label>
+  </form>
+  <script src="js/options.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
Create a basic options page for the extension
with theme change functionality
 The options page looks like this : 
![settings](https://user-images.githubusercontent.com/12656846/32138793-fb8f0dfc-bc56-11e7-9df8-d3630d00d319.png)

@djmgit @PaliwalSparsh Please review :)